### PR TITLE
Trajectories both versions

### DIFF
--- a/src/kOS/AddOns/Trajectories/Addon.cs
+++ b/src/kOS/AddOns/Trajectories/Addon.cs
@@ -114,7 +114,12 @@ namespace kOS.AddOns.TrajectoriesAddon
             }
             if (Available())
             {
-                return TRWrapper.HasTarget();
+                bool? result = TRWrapper.HasTarget();
+                if (result == null)
+                {
+                    throw new KOSException("Trajectories Addon :HASTARGET suffix seems to be missing.  It was added in Trajectories 2.0.0. and your version might be older.");
+                }
+                return result;
             }
             throw new KOSUnavailableAddonException("HASTARGET", "Trajectories");
         }

--- a/src/kOS/AddOns/Trajectories/TRWrapper.cs
+++ b/src/kOS/AddOns/Trajectories/TRWrapper.cs
@@ -39,42 +39,48 @@ namespace kOS.AddOns.TrajectoriesAddon
                 wrapped = false;
                 return;
             }
-            trGetImpactPosition = trajectoriesAPIType.GetMethod("GetImpactPosition");
+            // Trajectories 2.0.0 changed the capitalization of this method.  Trying both spellings here to support older Trajectories versions:
+            trGetImpactPosition = trajectoriesAPIType.GetMethod("GetImpactPosition") ?? trajectoriesAPIType.GetMethod("getImpactPosition");
             if (trGetImpactPosition == null)
             {
                 SafeHouse.Logger.Log("Trajectories.API.GetImpactPosition method is null.");
                 wrapped = false;
                 return;
             }
-            trCorrectedDirection = trajectoriesAPIType.GetMethod("CorrectedDirection");
+            // Trajectories 2.0.0 changed the capitalization of this method.  Trying both spellings here to support older Trajectories versions:
+            trCorrectedDirection = trajectoriesAPIType.GetMethod("CorrectedDirection") ?? trajectoriesAPIType.GetMethod("correctedDirection");
             if (trCorrectedDirection == null)
             {
                 SafeHouse.Logger.Log("Trajectories.API.CorrectedDirection method is null.");
                 wrapped = false;
                 return;
             }
-            trPlannedDirection = trajectoriesAPIType.GetMethod("PlannedDirection");
+            // Trajectories 2.0.0 changed the capitalization of this method.  Trying both spellings here to support older Trajectories versions:
+            trPlannedDirection = trajectoriesAPIType.GetMethod("PlannedDirection") ?? trajectoriesAPIType.GetMethod("plannedDirection");
             if (trPlannedDirection == null)
             {
                 SafeHouse.Logger.Log("Trajectories.API.PlannedDirection method is null.");
                 wrapped = false;
                 return;
             }
-            trHasTarget = trajectoriesAPIType.GetMethod("HasTarget");
+            // Trajectories 2.0.0 changed the capitalization of this method.  Trying both spellings here to support older Trajectories versions:
+            trHasTarget = trajectoriesAPIType.GetMethod("HasTarget") ?? trajectoriesAPIType.GetMethod("hasTarget");
             if (trHasTarget == null)
             {
                 SafeHouse.Logger.Log("Trajectories.API.HasTarget method is null.");
                 wrapped = false;
                 return;
             }
-            trSetTarget = trajectoriesAPIType.GetMethod("SetTarget");
+            // Trajectories 2.0.0 changed the capitalization of this method.  Trying both spellings here to support older Trajectories versions:
+            trSetTarget = trajectoriesAPIType.GetMethod("SetTarget") ?? trajectoriesAPIType.GetMethod("setTarget");
             if (trSetTarget == null)
             {
                 SafeHouse.Logger.Log("Trajectories.API.SetTarget method is null.");
                 wrapped = false;
                 return;
             }
-            trAlwaysUpdate = trajectoriesAPIType.GetProperty("AlwaysUpdate");
+            // Trajectories 2.0.0 changed the capitalization of this method.  Trying both spellings here to support older Trajectories versions:
+            trAlwaysUpdate = trajectoriesAPIType.GetProperty("AlwaysUpdate") ?? trajectoriesAPIType.GetProperty("alwaysUpdate");
             if (trAlwaysUpdate == null)
             {
                 wrapped = false;
@@ -105,8 +111,10 @@ namespace kOS.AddOns.TrajectoriesAddon
             return (Vector3?)trPlannedDirection.Invoke(null, new object[] { });
         }
 
-        public static bool HasTarget()
+        public static bool? HasTarget()
         {
+            if (trHasTarget == null)
+                return null;
             return (bool)trHasTarget.Invoke(null, new object[] { });
         }
 


### PR DESCRIPTION
This is what I did so far trying to support both old and new Trajectories API.  It does not include any of the checks for version number that you mentioned.

(Suggestion: update your ``Trajectories-v2.0.0-API-update`` branch from our ``develop`` first before looking at this.   The majority of the diffs you see here are not related to what I did and are just because ``develop`` has changed since this PR was first created.)